### PR TITLE
Update athom-smart-plug-v2.yaml for ESPhome 2024.6

### DIFF
--- a/athom-smart-plug-v2.yaml
+++ b/athom-smart-plug-v2.yaml
@@ -39,6 +39,7 @@ preferences:
 api:
 
 ota:
+  platform: esphome
 
 logger:
   baud_rate: 0


### PR DESCRIPTION
ESPHome 2024.6 seems to need the platform set in the ota configuration